### PR TITLE
Update README to match current site profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,101 +1,41 @@
-## Welcome
+# matt-adams.co.uk
 
-I'm a CISSP and CCSP certified Enterprise Security Architect, with expertise in assessing and implementing cyber security solutions to safeguard business critical assets.
+Source for my personal site, [matt-adams.co.uk](https://matt-adams.co.uk). Built with Jekyll and hosted on GitHub Pages. The site lives in the [`docs/`](docs/) folder.
 
-My strengths include: leading cyber risk assessments to assist clients to better understand and manage their exposure to cyber threats, enabling more informed business decision making; and architecting robust security solutions, incorporating a defence in depth approach to designing security controls in line with clients’ requirements.
+## About me
 
-I have a superior knowledge of information protection, securing assets throughout the data lifecycle from creation to destruction and also have extensive experience of delivering security improvement programmes to achieve a step change in organisational cyber security maturity levels, addressing potential security breaches and security audit recommendations.
+I'm a cybersecurity leader with 20 years' experience, currently heading AI security engineering and emerging technology security at a tier-1 global bank. I built the function from scratch, recruiting a multinational team, standing up an AI incubation environment, and delivering multiple security products into production.
 
-If you would like to contact me about a potential role then either please message me on [LinkedIn](https://www.linkedin.com/in/matthewrwadams/).
+I maintain open-source security tools with 2,200+ GitHub stars, co-lead a financial services industry working group on AI shared responsibility, and speak regularly at industry events on AI security and threat modelling.
 
-*****
+I write on the site about AI security, threat modelling, agentic AI, and whatever else I'm building or experimenting with.
 
-### My Expertise
-- Security Architecture
-- Security Risk Assessment
-- Security Assurance
-- Governance, Risk & Compliance
-- Data Loss Prevention
-- Data Classification
-- Security Transformation
-- Cloud Security (Azure, AWS) 
-- Team Leadership
-- Stakeholder Management
-- IRAM2
-- Information Protection
-- Project Management
-- Phishing / Social Engineering
+## Open-source projects
 
-*****
+- **[STRIDE-GPT](https://github.com/mrwadams/stride-gpt)** — AI-powered threat modelling tool supporting multiple LLM providers, with OWASP Top 10 for Agentic Applications mapping and multi-modal architectural analysis.
+- **[AttackGen](https://github.com/mrwadams/attackgen)** — Incident response scenario generation using the MITRE ATT&CK and ATLAS frameworks.
+- **[STRIDE-GPT MCP Server](https://github.com/mrwadams/mcp-stride-gpt)** — Model Context Protocol server giving AI assistants STRIDE threat modelling, DREAD risk scoring, attack tree generation, and reporting.
+- **[HoneyAgents](https://github.com/mrwadams/honeyagents)** — Proof-of-concept combining honeypots with autonomous AI agents for real-time threat detection and containment.
+- **[TM-Bench](https://github.com/mrwadams/tm-bench)** — Benchmark for evaluating LLM threat modelling capability across four scoring dimensions.
 
-### Experience
-#### Global Security Architect - Costa Coffee
-Jan 2020 - Present
+## Expertise
 
-Accountable for the development of information security architecture across the entire Costa Group.
+AI/ML security and agentic AI, security product engineering, threat modelling (STRIDE, DREAD, MITRE ATT&CK/ATLAS), security architecture and strategy, cloud security (AWS, Azure, GCP), zero trust, DevSecOps, and team building.
 
-<br>
+## Running the site locally
 
-#### Director - Cyber Threat Consulting
-Oct 2014 - Jan 2020 (5yrs 4 mos)
+The Jekyll site is in `docs/`:
 
-Operated as an independent contractor, delivering cyber security consultancy services to organisations such as Whitbread, NFU Mutual, The London Metal Exchange and the Department for Education. See details of contracts that I have delivered for clients below (and my permanent career prior to that).
+```bash
+cd docs
+bundle install
+bundle exec jekyll serve
+```
 
-<br>
+Then open http://localhost:4000.
 
-#### Senior Information Security Consultant / Architect - Whitbread (Contract)
-Jan 2019 - Dec 2019 (12 mos)
+## Contact
 
-Engaged to provide assurance and a conceptual design for security services to ensure secure separation of systems and data from the Whitbread IT estate as part of Coca-Cola’s acquisition of the Costa brand. Lead the production of a conceptual design for security services to ensure secure an equivalent level of protection for Costa data and applications pre and post migration. Reviewed solution designs proposed by the client's outsourced IT provider to identify potential gaps in capability and implementation of security standards (ISO 27001, CIS & Microsoft Security Baseline). Completed risk assessment of compliance gaps, providing pragmatic options for remediation.
-
-<br>
-
-#### Cyber Risk Management Consultant - NFU Mutual (Contract)
-Jun 2016 - Dec 2018 (2yrs 7 mos)
-
-Engaged to implement a new cyber risk assessment methodology to assist with the quantification of exposure to cyber security risks. Provided subject matter expertise for information security, advising business users on security best practices and provided second-line assurance of security controls implemented by strategic projects. Also provided GDPR and data protection compliance guidance to strategic business projects.
-
-Key achievements:
-- Performed enterprise-wide risk assessment using IRAM2 methodology.
-- Procured and implemented a Governance, Risk & Compliance tool (Nasdaq BWise) introducing enhanced rigor for risk assessment processes and reporting to senior management.
-- Developed risk reporting dashboards to display high and low-level views of security risks.
-- Succeeded in delivering a cyber risk assessment methodology enabling NFUM to quantify its exposure to existing and emerging risks, the output was used to determine the priorities and scope of a £3m security improvement programme.
-
-<br>
-
-#### Cyber Security / Information Security Manager - Department for Education (Contract)
-Apr 2016 - Jun 2016 (3 mos)
-
-Engaged on short term contract to leverage my expertise of Government information assurance and security requirements for public sector organisations.
-
-Key achievements:
-- Led production of a detailed risk assessment and risk treatment plan in support of the Department’s migration of all key line-of-business applications to a cloud hosting environment.
-- Produced a Privacy Impact Assessment for six new cyber security capabilities to be implemented by the Department to protect business critical systems and data hosted in a cloud computing environment.
-
-<br>
-
-#### Information Security Consultant - London Metal Exchange (Contract)
-Feb 2014 - Apr 2016 (2yrs 3 mos)
-
-Engaged as Information Security Consultant to significantly improve the cyber security maturity of the organisation following identified security shortfalls in an external audit by KPMG.
-
-Key achievements:
-- Designed and delivered a comprehensive cyber security awareness campaign across the business. This included coordinating regular phishing awareness tests using Cofense PhishMe to quantify the risk of the business being compromised by a successful spear phishing attack.
-- Project managed the delivery of a new company-wide web filtering solution to reduce the risk of phishing and drive-by download attacks. This solution replaced three separate legacy filtering technologies, significantly simplifying the management of filtering policies across the estate.
-- Led the delivery of a new secure email solution to automatically encrypt outbound email based on the sensitivity classification of the email, or other policy criteria defined by business users.
-- Implemented a new data governance system to scan unstructured data stores in order to identify sensitive files and configure appropriate access permissions based on each user’s department and role.
-- Implemented data leakage prevention controls for corporate email and web traffic. These policy-based controls utilised a combination of keyword matching and data classification metadata to identify sensitive files and prevent them from being sent outside the corporate network.
-- Successfully improved security maturity level, meeting all national critical infrastructure requirements and addressing KPMG audit concerns. Introduction of improved security capabilities underpinned successful completion of CBEST testing.
-
-<br>
-
-#### Earlier Career - Deloitte
-2006 - 2014 (8yrs)
-
-Various positions within the Technology, Assurance & Advisory and Security & Resilience teams, graduating from Consultant to Senior Manager positions.
-
-Key achievements:
-- Responsible for leading Deloitte's Information Protection services in the UK, including the development and implementation of data loss prevention, mobile device management and data classification technology solutions for leading organisations.
-- Completed a 6-month secondment at Ingeus, a global provider of employability services. Worked closely with the business’s CIO to develop and embed a refreshed set of information security policies and procedures aligned to ISO 27001, ensuring compliance with UK Government security requirements.
-- Key contributor to the development of a target operating model for AXA, a multinational insurance company. The deliverables included a refreshed organisation design, governance model and security activity catalogue, all of which were aligned to the business’s goals for the new security organisation.
-- Managed Deloitte’s involvement in a multidisciplinary team of information security specialists tasked by the CIO of AXA to identify and remediate significant security weaknesses in business-critical applications and network infrastructure.
+- CV: [matt-adams.co.uk/cv](https://matt-adams.co.uk/cv/)
+- LinkedIn: [matthewrwadams](https://www.linkedin.com/in/matthewrwadams/)
+- GitHub: [mrwadams](https://github.com/mrwadams)


### PR DESCRIPTION
## Summary
The root `README.md` mirrored an outdated version of the site homepage (Enterprise Security Architect at Costa Coffee, CISSP/CCSP intro). This rewrite aligns it with the current `docs/about.markdown`, `docs/index.markdown`, and `docs/cv.markdown` pages.

## Changes
- Lead with the current profile: cybersecurity leader heading AI security engineering and emerging technology security at a tier-1 global bank.
- Add current open-source projects (STRIDE-GPT, AttackGen, MCP Server, HoneyAgents, TM-Bench) and the 2,200+ GitHub stars line.
- Refresh the expertise summary (AI/ML security, agentic AI, threat modelling, cloud security, DevSecOps).
- Reframe as a repo README: note it's the Jekyll source for matt-adams.co.uk and add local-run instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)