### PR TITLE
Add projects showcase and speaker one-sheet pages

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -34,13 +34,14 @@ remote_theme: jekyll/minima
 plugins:
   - jekyll-feed
 
-header_pages:
-  - about.markdown
-  - cv.markdown
-  - links.markdown
-
 minima:
   skin: dark
+  nav_pages:
+    - about.markdown
+    - cv.markdown
+    - projects.markdown
+    - speaking.markdown
+    - links.markdown
 
 
 # Exclude from processing.

--- a/docs/projects.markdown
+++ b/docs/projects.markdown
@@ -1,0 +1,71 @@
+---
+layout: page
+title: Projects
+permalink: /projects/
+---
+
+I build open-source tools and research at the intersection of AI and security. Most of it started as a way to solve a problem I had at work: threat modelling that took too long, incident response exercises that went stale, and a growing pile of AI security frameworks that nobody had lined up side by side.
+
+Together these tools have 2,200+ GitHub stars. Here's what I'm working on.
+
+<br>
+
+-----
+
+## Open-source tools
+
+### STRIDE-GPT
+
+An AI threat modelling tool that uses large language models to generate threat models, attack trees, and DREAD risk scores from the STRIDE methodology. It runs as a Streamlit web app and, since v0.16, as an agentic CLI (`pip install stride-gpt`) that can analyse a whole codebase on its own. Threats are tagged with MITRE ATT&CK and ATLAS technique IDs, and it works with OpenAI, Anthropic, Google, Mistral, Groq, and local models via Ollama or LM Studio. Around 1,080 GitHub stars.
+
+[GitHub](https://github.com/mrwadams/stride-gpt) &bull; [Live demo](https://stridegpt.streamlit.app/)
+
+<br>
+
+### AttackGen
+
+Generates incident response exercises from the MITRE ATT&CK and ATLAS frameworks. Pick a threat actor group or a set of techniques and it writes a realistic scenario for a tabletop. Purple-team mode pairs each offensive scenario with a detection and response narrative, and there's an MCP server plus a tabletop skill so you can build and refine exercises in conversation with an AI assistant. Around 1,220 GitHub stars.
+
+[GitHub](https://github.com/mrwadams/attackgen) &bull; [Live demo](https://attackgen.streamlit.app/)
+
+<br>
+
+### STRIDE-GPT MCP Server
+
+A Model Context Protocol server that gives AI assistants the STRIDE-GPT toolset directly: threat modelling, DREAD risk scoring, attack tree generation, security test cases, and reporting. Add it to Claude Desktop or any MCP-compatible client and ask for a threat model in plain language. Currently in beta.
+
+[GitHub](https://github.com/mrwadams/mcp-stride-gpt) &bull; [Hosted server](https://mcp.stridegpt.ai/)
+
+<br>
+
+-----
+
+## Research and frameworks
+
+### TM-Bench
+
+A benchmark for how well LLMs actually do threat modelling. It scores models across four dimensions against a private test set, with a focus on models you can run on consumer hardware like a single RTX 4090. The point is to help teams choose a model for local security work with data rather than vibes.
+
+[Website](https://www.tmbench.com) &bull; [Methodology](https://www.tmbench.com/methodology)
+
+<br>
+
+### AI Insider Threat Model
+
+A framework that treats frontier AI agents as potential insider threats rather than just targets or tools. It adapts CERT's insider threat dimensions (motivation, opportunity, capability) to autonomous agents, maps 23 STRIDE threats across six categories, profiles risk across four levels of autonomy, and offers a NIST-aligned set of controls that slots into insider threat programmes teams already run.
+
+[Read the framework](https://ai-insider-threat.matt-adams.co.uk/)
+
+<br>
+
+### OWASP AI Top 10 Comparator
+
+There are now five OWASP Top 10 lists for AI security (LLM Applications, Agentic Applications, MCP, Agentic Skills, and ML Security), covering 50 distinct risks at very different levels of maturity. This tool puts all five side by side: where they overlap, where each one is silent, how each risk maps to Simon Willison's Lethal Trifecta, and which lists actually apply to your stack.
+
+[Try the comparator](https://owaspai.matt-adams.co.uk/)
+
+<br>
+
+-----
+
+There's more on my [GitHub](https://github.com/mrwadams), including [HoneyAgents](https://github.com/mrwadams/honeyagents) and an [OTX MCP server](https://github.com/mrwadams/otx-mcp). You can also [ask an AI about my work](/cv/) through the MCP server I've published.

--- a/docs/speaking.markdown
+++ b/docs/speaking.markdown
@@ -1,0 +1,59 @@
+---
+layout: page
+title: Speaking
+permalink: /speaking/
+---
+
+I speak at industry events on AI security, threat modelling, and what happens when autonomous agents start acting inside enterprise systems. I've got nearly 20 years in cybersecurity and currently head AI security engineering and emerging technology security at a tier-1 global bank, so most of my talks come with live demos and examples from real production work rather than slideware.
+
+My largest stage so far was UNLEASH World 2025 in Paris, one of the biggest HR and technology events in the world with 8,200 delegates, where I joined a fireside panel alongside Microsoft's Corporate Vice President for Discovery and Quantum.
+
+<br>
+
+-----
+
+## What I speak about
+
+- Treating frontier AI agents as insider threats, and what that changes for CISOs
+- AI-powered security tooling: taking threat modelling and incident response from proof of concept to production
+- Practical uses of generative AI in security teams
+- Securing agentic AI and emerging technology in financial services
+- Building open-source security tools
+
+<br>
+
+-----
+
+## Selected engagements
+
+| Event | Date | Format | Audience |
+|---|---|---|---|
+| Securing Financial Services Summit, London | Jul 2026 | Conference talk | CISOs and risk leaders in financial services |
+| Securing the Law Firm, London | Jul 2026 | Conference talk | Law firm CISOs and security leaders |
+| AI in Financial Services Deep Dive, London | Nov 2025 | Conference talk with live demos | FS technology and security leaders |
+| XLoD Global, London | Nov 2025 | Plenary panel | Global security and technology leaders |
+| UNLEASH World, Paris | Oct 2025 | Fireside panel | HR and technology leaders (8,200-delegate event) |
+| Liberty Global Geek Fest, Amsterdam | Sep 2025 | Keynote and panel | Board members and CTIOs |
+| Open Security Summit | Jan 2024 | Technical talk | 100+ security professionals |
+| OWASP London Chapter | Aug 2023 | Meetup talk | 50+ security professionals |
+
+<br>
+
+Talk topics have ranged from "Actions Speak Louder Than Tokens: Treating Frontier AI Agents as Insider Threats", which I gave at both the Securing Financial Services Summit and its sister event Securing the Law Firm, to "Doing More with Less: Practical Applications for Generative AI in Cybersecurity" at OWASP London. Recordings from the OWASP London and Open Security Summit talks are on [YouTube](https://youtu.be/cwZDqJFhYAo).
+
+<br>
+
+-----
+
+## Media and publications
+
+- **Software Engineering Radio, Episode 648** (Dec 2024): an hour on AI threat modelling and STRIDE-GPT with host Priyanka Raghavan. [Listen](https://se-radio.net/2024/12/se-radio-648-matthew-adams-on-ai-threat-modeling-and-stride-gpt/)
+- **IEEE Software** (2025): a technical article on AI threat modelling and STRIDE-GPT. [DOI: 10.1109/MS.2025.3540515](https://doi.org/10.1109/MS.2025.3540515)
+
+<br>
+
+-----
+
+## Invite me to speak
+
+I'm available for conferences, chapter meetups, corporate workshops, panels, and podcasts. The best way to reach me is on [LinkedIn](https://www.linkedin.com/in/matthewrwadams/).


### PR DESCRIPTION
## What

Adds two human-facing pages to matt-adams.co.uk, sourced from the same structured content that drives the MCP server (mcp.matt-adams.co.uk), so there's a canonical link for speaking pitches, sponsors, and advisory conversations to point at.

- **`/projects/`** — showcase of the six documented projects, split into open-source tools (STRIDE-GPT, AttackGen, STRIDE-GPT MCP Server) and research/frameworks (TM-Bench, AI Insider Threat Model, OWASP AI Top 10 Comparator), each with a plain description and links.
- **`/speaking/`** — speaker one-sheet: topics, a selected-engagements table with venues/dates/audience sizes (including UNLEASH World Paris, an 8,200-delegate event), media appearances (SE Radio Ep 648), and publications (IEEE Software).

## Nav

Both pages are wired into the top nav via `minima.nav_pages` in `docs/_config.yml`, ordered About · CV · Projects · Speaking · AI Security Resources. Note: the site renders minima's master branch through `remote_theme`, which reads `nav_pages` (not `header_pages`).

## Notes

- Copy is written in a neutral, first-person voice consistent with the existing about/cv pages; the employer is referred to as "a tier-1 global bank".
- Verified with a local `bundle exec jekyll build` (clean) and by spot-checking the rendered `_site` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)